### PR TITLE
fix: glob matching on windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,10 +86,14 @@ function VitePluginRestart(options: Options = {}): Plugin {
     configResolved(config) {
       if (fs.existsSync('vite.config.ts'))
         configFile = 'vite.config.ts'
+      
+      // famous last words, but this *appears* to always be an absolute path
+      // with all slashes normalized to forward slashes `/`. this is compatible
+      // with path.posix.join, so we can use it to make an absolute path glob
       root = config.root
-
-      reloadGlobs = toArray(options.reload).map(i => pathPlatform.resolve(root, i))
-      restartGlobs = toArray(options.restart).map(i => pathPlatform.resolve(root, i))
+      
+      restartGlobs = toArray(options.restart).map(i => path.posix.join(root, i))
+      reloadGlobs = toArray(options.reload).map(i => path.posix.join(root, i))
     },
     configureServer(server) {
       server.watcher.add([


### PR DESCRIPTION
## Problem
Noticed that only complete paths are working on windows, we transform `/` to `\` on windows when we use `path.win32.resolve` and this produces incorrect globs for `micromatch`

`server.watcher` still fires an event, but I think that `server.watcher.add` is trying to be cute and transforming the `\`'s before giving them to `micromatch`.  (which ofc has the downside that it might break for some glob patterns with escaped characters)

## Background

micromatch documentation about backslashes:
https://github.com/micromatch/micromatch#backslashes

## Breaking changes

Windows users who used mixed slashes (both `/` and `\`) in the same filename will no longer restart when an exactly matching filename is changed. They will need to change to only using forward slash (and reserve backslash for escaping)

## testing

I edited this via web and haven't been able to test this code on linux/mac yet, but it's identical to the changes I have locally. I'll try to get in a quick test on linux after work today, to make sure that `config.root` behaves the same there.

