### PR TITLE
Force tsup to treat code as module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vite-plugin-restart",
   "version": "0.2.0",
+  "type": "module",
   "packageManager": "pnpm@7.5.0",
   "description": "Custom files/globs to restart Vite server",
   "author": "antfu <anthonyfu117@hotmail.com>",


### PR DESCRIPTION
### Description

Solves #14 import double/triple default glitch

### Linked Issues

#14

### Additional context

Default ESM export is an object, containing a property, called default. This is to be expected of CJS, but not an MJS file.

![Screenshot_20221109-235547](https://user-images.githubusercontent.com/876076/200864858-436615ef-599d-45b1-81b4-2ab6d2966ef4.png)

