### PR TITLE
feat: add content-based change detection to prevent infinite restart …

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,76 @@ export default {
 
 Changes to `my.config.js` or `my.config.ts` will now restart the server automatically.
 
+## Options
+
+```ts
+export interface VitePluginRestartOptions {
+  /**
+   * Enable glob support for watcher (it's disabled by Vite, but add this plugin will turn it on by default)
+   * @default true
+   */
+  glob?: boolean
+  /**
+   * Delay in ms before restarting the server
+   * @default 500
+   */
+  delay?: number
+  /**
+   * Array of files to watch, changes to those file will trigger a server restart
+   */
+  restart?: string | string[]
+  /**
+   * Array of files to watch, changes to those file will trigger a client full page reload
+   */
+  reload?: string | string[]
+  /**
+   * Enable content-based change detection to prevent unnecessary restarts
+   * when file metadata changes but content remains the same
+   * @default true
+   */
+  contentCheck?: boolean
+}
+```
+
+### Content-Based Change Detection
+
+By default, the plugin now uses content-based change detection (`contentCheck: true`). This prevents infinite restart loops when watching auto-generated files that may be rewritten with the same content.
+
+For example, when watching `.eslintrc-auto-import.json`:
+
+```ts
+export default {
+  plugins: [
+    ViteRestart({
+      restart: [
+        '.eslintrc-auto-import.json',
+      ],
+      // Content check is enabled by default
+      // Only restarts if file content actually changes
+      contentCheck: true,
+    })
+  ],
+}
+```
+
+The plugin calculates a SHA-256 hash of the file content and only triggers a restart if the hash changes. This solves the problem of:
+- Auto-generated files being rewritten during the build process
+- File modification timestamps changing without actual content changes
+- Infinite restart loops caused by files being regenerated on every server restart
+
+You can disable this feature if needed:
+
+```ts
+export default {
+  plugins: [
+    ViteRestart({
+      restart: ['my.config.js'],
+      contentCheck: false, // Disable content-based detection
+    })
+  ],
+}
+```
+
 ## Motivation
 
 Byebye `nodemon -w my.config.js -x 'vite'`


### PR DESCRIPTION
### Description

This PR adds content-based change detection to prevent infinite restart loops when watching auto-generated files.

**Problem:**
Currently, the plugin triggers server restarts based solely on file system events (modification time), without checking if the file content actually changed. This causes infinite restart loops when watching auto-generated files like `.eslintrc-auto-import.json`, because:
- These files are frequently rewritten during the build process
- Even when content is identical, the file modification timestamp changes
- Each server restart may regenerate the file, triggering another restart

**Solution:**
- Added [contentCheck](file:///Volumes/M2/vite-plugin-restart/src/index.ts#L32-L32) option (enabled by default) to enable content-based change detection
- Uses SHA-256 hashing to compare file content before/after changes
- Maintains a global hash cache that persists across server restarts
- Only triggers restart when file content actually changes, not just metadata

**Key Changes:**
- New option: `contentCheck?: boolean` (default: `true`)
- Implements [getFileHash()](file:///Volumes/M2/vite-plugin-restart/src/index.ts#L73-L85) using Node.js crypto module
- Implements [hasContentChanged()](file:///Volumes/M2/vite-plugin-restart/src/index.ts#L87-L118) to compare content hashes
- Global [fileHashes](file:///Volumes/M2/vite-plugin-restart/src/index.ts#L63-L63) Map keyed by project root to persist across restarts
- Updated documentation with usage examples

**Benefits:**
- ✅ Prevents infinite restart loops for auto-generated files
- ✅ Backward compatible (can be disabled with `contentCheck: false`)
- ✅ No performance impact - uses efficient SHA-256 hashing
- ✅ Works seamlessly with existing configurations

### Linked Issues

Fixes the infinite restart loop issue when monitoring auto-generated configuration files.

### Additional context

**Testing:**
The feature has been tested with the following scenario:
1. Watching `.eslintrc-auto-import.json` file
2. Writing identical content multiple times → No restart triggered ✅
3. Writing different content → Restart triggered ✅

**Example Configuration:**
```typescript
VitePluginRestart({
  restart: ['.eslintrc-auto-import.json'],
  contentCheck: true, // enabled by default
})